### PR TITLE
travis continuous integration for GHC 7.4, 7.6, 7.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+# NB: don't set `language: haskell` here
+
+# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
+env:
+ - GHCVER=7.4.2 CABALVER=1.22
+ - GHCVER=7.6.3 CABALVER=1.22
+ - GHCVER=7.8.4 CABALVER=1.22 #ghc 7.8 versions, see note about alex and happy
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head CABALVER=1.22
+
+# Note: the distinction between `before_install` and `install` is not important.
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal --version
+ - cabal update
+ - cabal install -j -O2 packdeps
+
+install:
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+# Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+ - cabal --version | grep --quiet '1.22';
+   if [ $? -eq 0 ]; then
+      find . -name '*.cabal' | xargs cabal exec packdeps;
+   fi
+
+# The following scriptlet checks that the resulting source distribution can be built & installed
+ - export SRC_TGZ=$(cabal-$CABALVER info . | awk '{print $2 ".tar.gz";exit}') ;
+   cd dist/;
+   if [ -f "$SRC_TGZ" ]; then
+      cabal install "$SRC_TGZ";
+   else
+      echo "expected '$SRC_TGZ' not found";
+      exit 1;
+   fi
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: GHCVER=head CABALVER=1.22 # see section about GHC HEAD snapshots
+    - env: GHCVER=7.10.1 CABALVER=1.22

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -7,6 +7,8 @@ maintainer:    Ivan.Miljenovic@gmail.com
 homepage:      http://web.engr.oregonstate.edu/~erwig/fgl/haskell
 category:      Data Structures, Graphs
 synopsis:      Martin Erwig's Functional Graph Library
+description:
+  The functional graph library for Haskell provides several modules that define inductive graphs and graph algorithms.
 cabal-version: >= 1.6
 build-type:    Simple
 extra-source-files:


### PR DESCRIPTION
Following Sven Panne's reccomendation on the mailing list I created a .travis.yml for this project based on @hvr's https://github.com/hvr/multi-ghc-travis work.

There's a passing run here: https://travis-ci.org/cheecheeo/fgl/builds/53483057

To setup travis-ci for this repo you'll want to follow: http://docs.travis-ci.com/user/getting-started/ this patch provides step 3 of the howto.

You'll probably want to follow steps 1 and 2 before merging this commit so that when the you merge this pull request the travis build will be automatically triggered.

Review comments or questions are welcome.