### PR TITLE
Add subgraph-related functions.

### DIFF
--- a/test/Data/Graph/Inductive/Graph/Properties.hs
+++ b/test/Data/Graph/Inductive/Graph/Properties.hs
@@ -343,6 +343,32 @@ valid_buildGr g = equal g (buildGr cs)
   where
     cs = ufold (:) [] g
 
+-- | Tests `gfiltermap` with a function accepting all contexts.
+gfiltermap_id :: (DynGraph gr, Eq a, Eq b) => gr a b -> Bool
+gfiltermap_id g = equal (gfiltermap Just g) g
+
+-- | Tests `nfilter` with a function accepting all nodes.
+nfilter_true :: (DynGraph gr, Eq a, Eq b) => gr a b -> Bool
+nfilter_true g = equal (nfilter (\_ -> True) g) g
+
+-- | Tests `labnfilter` with a function accepting all nodes.
+labnfilter_true :: (DynGraph gr, Eq a, Eq b) => gr a b -> Bool
+labnfilter_true g = equal (labnfilter (\_ -> True) g) g
+
+-- | Tests `labnfilter` with a function accepting all nodes.
+labfilter_true :: (DynGraph gr, Eq a, Eq b) => gr a b -> Bool
+labfilter_true g = equal (labfilter (\_ -> True) g) g
+
+-- | The subgraph induced by a list of nodes should contain exactly
+-- the nodes from this list, as well as all edges between these nodes.
+valid_subgraph :: (DynGraph gr, Eq b, Ord b) => gr a b -> Gen Bool
+valid_subgraph gr = do
+  vs <- sublistOf $ nodes gr
+  let sg = subgraph vs gr
+      svs = S.fromList vs
+      subedges = filter (\(v,w,_) -> v `S.member` svs && w `S.member` svs) $ labEdges gr
+  return $ sort (nodes sg) == sort vs && sort (labEdges sg) == sort subedges
+
 -- -----------------------------------------------------------------------------
 -- Miscellaneous
 

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -57,21 +57,26 @@ graphTests nm p = describe nm $ do
     propType  "test_hasLEdge"   test_hasLEdge
 
   describe "Dynamic tests" $ do
-    propType  "merging (&)"     valid_merge
-    propType  "gmap (id)"       gmap_id
-    propType  "insNode"         valid_insNode
-    propType  "insNodes"        valid_insNodes
-    propType  "insEdge"         valid_insEdge
-    propType  "insEdges"        valid_insEdges
-    propType  "insEdges (mult)" valid_insEdges_multiple
-    propType  "delNode"         valid_delNode
-    propType  "delNodes"        valid_delNodes
-    propType  "delEdge"         valid_delEdge
-    propType  "delEdges"        valid_delEdges
-    propType  "delLEdge"        valid_delLEdge
-    propType  "delAllLEdge"     valid_delAllLEdge
-    proxyProp "valid_mkGraph"   valid_mkGraph
-    propType  "valid_buildGr"   valid_buildGr
+    propType  "merging (&)"       valid_merge
+    propType  "gmap (id)"         gmap_id
+    propType  "insNode"           valid_insNode
+    propType  "insNodes"          valid_insNodes
+    propType  "insEdge"           valid_insEdge
+    propType  "insEdges"          valid_insEdges
+    propType  "insEdges (mult)"   valid_insEdges_multiple
+    propType  "delNode"           valid_delNode
+    propType  "delNodes"          valid_delNodes
+    propType  "delEdge"           valid_delEdge
+    propType  "delEdges"          valid_delEdges
+    propType  "delLEdge"          valid_delLEdge
+    propType  "delAllLEdge"       valid_delAllLEdge
+    proxyProp "valid_mkGraph"     valid_mkGraph
+    propType  "valid_buildGr"     valid_buildGr
+    propType  "gfiltermap (id)"   gfiltermap_id
+    propType  "nfilter (true)"    nfilter_true
+    propType  "labnfilter (true)" labnfilter_true
+    propType  "labfilter (true)"  labfilter_true
+    propType  "subgraph"          valid_subgraph
 
   where
     proxyProp str = prop str . ($p)


### PR DESCRIPTION
This pull request adds `gfiltermap` which allows building a graph out of certain transformed contexts of the original one.  It then adds `nfilter'` and `nfilter` which allow constructing a subgraph by filtering by node labels or by node numbers.  Finally, the function `subgraph` proper is added.