### PR TITLE
Informative error message for `insEdge`

### DIFF
--- a/Data/Graph/Inductive/Graph.hs
+++ b/Data/Graph/Inductive/Graph.hs
@@ -226,7 +226,10 @@ insNode (v,l) = (([],v,l,[])&)
 insEdge :: (DynGraph gr) => LEdge b -> gr a b -> gr a b
 insEdge (v,w,l) g = (pr,v,la,(l,w):su) & g'
   where
-    (Just (pr,_,la,su),g') = match v g
+    (mcxt,g') = match v g
+    (pr,_,la,su) = fromMaybe
+                     (error ("insEdge: cannot add edge from non-existent vertex " ++ show v))
+                     mcxt
 
 -- | Remove a 'Node' from the 'Graph'.
 delNode :: (Graph gr) => Node -> gr a b -> gr a b


### PR DESCRIPTION
As documented in haskell/fgl#14 , an irrefutable pattern exception is
thrown when attempting to insert an edge from a vertex that does not
exist in the graph, .e.g

    insEdge (0,1,"foo") (mkGraph [] [])

The previous behaviour of fgl was:

mkGraph *** Exception: Data/Graph/Inductive/Graph.hs:229:5-38: Irrefutable pattern failed for pattern (Just (pr, _, la, su), g')

The new behaviour is:

mkGraph *** Exception: insEdge: unable to add edge from non-existent vertex 0

closes haskell/fgl#14