### PR TITLE
Fix the names of test cases of neighbour-related functions.

### DIFF
--- a/test/Data/Graph/Inductive/Graph/Properties.hs
+++ b/test/Data/Graph/Inductive/Graph/Properties.hs
@@ -137,20 +137,20 @@ gelem_in_nodes g = all (liftA2 (==) (`gelem`g) (`S.member`ns))
 
 -- | Check that having a labelled edge in a graph is equivalent to
 -- 'hasNeighborAdj' reporting that the edge is there.
-test_hasNeighborAdj :: (Graph gr, Eq b, Show b) => gr a b -> Node -> Node -> b -> Bool
-test_hasNeighborAdj gr v w l = ( any (`elem` [ (v,w,l), (w,v,l) ]) $ labEdges gr )
-                               == (hasNeighborAdj gr v (l,w) && hasNeighborAdj gr w (l,v))
+valid_hasNeighborAdj :: (Graph gr, Eq b, Show b) => gr a b -> Node -> Node -> b -> Bool
+valid_hasNeighborAdj gr v w l = ( any (`elem` [ (v,w,l), (w,v,l) ]) $ labEdges gr )
+                                == (hasNeighborAdj gr v (l,w) && hasNeighborAdj gr w (l,v))
 
 -- | Check that having an edge in a graph is equivalent to
 -- 'hasNeighbor' reporting that the edge is there.
-test_hasNeighbor :: (Graph gr, Eq b) => gr a b -> Node -> Node -> Bool
-test_hasNeighbor gr v w =
+valid_hasNeighbor :: (Graph gr, Eq b) => gr a b -> Node -> Node -> Bool
+valid_hasNeighbor gr v w =
   ( any (`elem` [ (v,w), (w,v) ]) $ edges gr ) == (hasNeighbor gr v w && hasNeighbor gr w v)
 
 -- | Check that having a labelled edge in a graph is equivalent to
 -- 'hasLEdge' reporting that the edge is there.
-test_hasLEdge :: (Graph gr, Eq b) => gr a b -> LEdge b -> Bool
-test_hasLEdge gr e = (e `elem` labEdges gr) == hasLEdge gr e
+valid_hasLEdge :: (Graph gr, Eq b) => gr a b -> LEdge b -> Bool
+valid_hasLEdge gr e = (e `elem` labEdges gr) == hasLEdge gr e
 
 -- -----------------------------------------------------------------------------
 -- Dynamic graphs

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -52,9 +52,9 @@ graphTests nm p = describe nm $ do
     propType  "ufold (nodes)"   ufold_all_nodes
     propType  "gelem"           all_nodes_gelem
     propType  "gelem vs nodes"  gelem_in_nodes
-    propType  "test_hasNeighborAdj" test_hasNeighborAdj
-    propType  "test_hasNeighbor" test_hasNeighbor
-    propType  "test_hasLEdge"   test_hasLEdge
+    propType  "hasNeighborAdj"  valid_hasNeighborAdj
+    propType  "hasNeighbor"     valid_hasNeighbor
+    propType  "hasLEdge"        valid_hasLEdge
 
   describe "Dynamic tests" $ do
     propType  "merging (&)"       valid_merge


### PR DESCRIPTION
The names of tests for functions `hasNeighborAdj`, `hasNeighbour`, and `hasLEdge` started with `test_`.  Change this to `valid_`.