### PR TITLE
Implement faster shortest and longest path finding algorithms 

### DIFF
--- a/Data/Graph/Inductive/Query/SP.DAG.hs
+++ b/Data/Graph/Inductive/Query/SP.DAG.hs
@@ -1,0 +1,159 @@
+module Data.Graph.Inductive.Query.SP.DAG (
+      shortestPathBetweenNodes
+    , shortestPathFromSource
+    , shortestPath
+    , longestPathBetweenNodes
+    , longestPathFromSource
+    , longestPath
+    , tracePath
+    , runPaths
+) where
+
+import Data.Graph.Inductive.Graph
+import Data.Vector (minIndex,maxIndex,freeze,(!))
+import Data.Mutable.Vector (IOVector,write,set,read,new)
+import Control.Monad (MonadPlus,mplus,mzero)
+import Data.Foldable (foldl',Foldable)
+
+shortestPathBetweenNodes :: (Graph gr, Real b, Foldable f)
+    => Node -- ^ Start
+    -> Node -- ^ Destination
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+shortestPathBetweenNodes s t l top g = do
+    (_,pred) <- runPaths (Just s) (Just 0) Nothing (<) l top g
+    return $ tracePath t pred
+
+shortestPathFromSource :: (Graph gr, Real b, Foldable f)
+    => Node -- ^ Source
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+shortestPathFromSource s l top g = do
+    (dist,pred) <- runPaths (Just s) (Just 0) Nothing (<) l top g
+    return $ tracePath (minIndex dist) pred
+
+shortestPath :: (Graph gr, Real b, Foldable f)
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+shortestPath l t g = do
+    (dist,pred) <- runPaths Nothing Nothing (Just 0) (<) l top g
+    return $ tracePath (minIndex dist) pred
+
+longestPathBetweenNodes :: (Graph gr, Real b, Foldable f)
+    => Node -- ^ Start
+    -> Node -- ^ Destination
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+longestPathBetweenNodes s t l top g = do
+    (_,pred) <- runPaths (Just s) (Just 0) Nothing (>) l top g
+    return $ tracePath t pred
+
+longestPathFromSource :: (Graph gr, Real b, Foldable f)
+    => Node -- ^ Source
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+longestPathFromSource s l top g = do
+    (dist,pred) <- runPaths (Just s) (Just 0) Nothing (>) l top g
+    return $ tracePath (maxIndex dist) pred
+
+longestPath :: (Graph gr, Real b, Foldable f)
+    -> Int  -- ^ length of topsort
+    -> f Node -- ^ topsort
+    -> gr a b
+    -> IO Path
+longestPath l t g = do
+    (dist,pred) <- runPaths Nothing Nothing (Just 0) (>) l top g
+    return $ tracePath (maxIndex dist) pred
+
+tracePath :: MonadPlus m 
+    => Node -- ^ End node of path
+    -> Vector (Maybe Node) -- ^ Vector of predecessors
+    -> m Node
+tracePath n v = 
+    case v ! n of
+         Just node 
+              -> mplus node $ tracepath node v
+         Nothing 
+              -> mzero
+
+runPaths = freezeVecs <$> runPaths'
+
+freezeVecs ::
+    (IOVector a, IOVector b)
+    -> IO (Vector a, Vector b)
+freezeVecs (v1,v2) = do
+    vec1 <- freeze v1
+    vec2 <- freeze v2
+    return (vec1,vec2)
+
+runPaths' :: (Graph gr, Real b, Foldable f)
+    => Maybe Node -- Source node
+    -> Maybe Int -- ^ Source node initialization value
+    -> Maybe Int -- ^ Distances vector init values
+    -> (Int -> Int -> Bool) -- ^ Comparison to use on nodes
+    -> Int -- ^ Length of the top sort
+    -> f Node -- ^ Topological sorting of the graph in some foldable format
+    -> gr a b
+    -> IO (IOVector (Maybe Int), IOVector (Maybe Node))
+runPaths' s v distV n comp t g = do
+    (distances,predecessors) <- genVectors n distV Nothing
+    case s of 
+         Just source -> write distances source v
+         Nothing -> return ()
+    pathsByComparison distances predecessors comp t g
+    return (distances,predecessors)
+
+genVectors :: 
+    Int -- ^ Length of the vectors, ie, length of the graph or topsort
+    -> a
+    -> b
+    -> IO (IOVector a, IOVector b)
+genVectors n val1 val2 = do
+    distances <- new (n + 1)
+    predecessors <- new (n + 1)
+    set distances val1
+    set predecessors val2
+    return (distances,predecessors)
+
+pathsByComparison :: (Graph gr, Real b, Foldable f)
+    => IOVector (Maybe Int) -- ^ Vector that will hold accumulated weights 
+    -> IOVector (Maybe Node)
+    -> (Int -> Int -> Bool)
+    -> f Node -- Topological sorting of the graph in some foldable format
+    -> gr a b
+    -> IO (IOVector (Maybe Weight), IOVector (Maybe Node))
+pathsByComparison dist pred comp top graph =
+    foldl' (\_ node
+        -> updateSuccessors dist pred comp node graph)
+        (return (dist, pred)) top 
+
+
+updateSuccessors :: (Graph gr, Real b)
+    => IOVector (Maybe Int)
+    -> IOVector (Maybe Node)
+    -> (Int -> Int -> Bool)
+    -> Node
+    -> gr a b
+    -> IO (IOVector (Maybe Int), IOVector (Maybe Node))
+updateSuccessors distances predecessors comparison t g = 
+    let successors = lsuc g t in do
+    sequence_ $ map (\(successor,weight) -> do
+        ds <- read distances successor
+        dt <- read distances t
+        if comparison ds (dt + weight)
+            then do
+                write distances successor $ Just (dt + weight)
+                write predecessors successor $ Just t
+            else return ())
+        outs
+    return (distances,predecessors)

--- a/Data/Graph/Inductive/Query/SP/DAG.hs
+++ b/Data/Graph/Inductive/Query/SP/DAG.hs
@@ -31,8 +31,8 @@ import Data.Graph.Inductive.Graph
 import Data.Vector (Vector,maxIndex,freeze,(!))
 import Data.Vector.Mutable (IOVector,write,set,read,new)
 import Control.Monad (MonadPlus,mplus,mzero)
-import Data.Foldable (foldl')
-
+import Data.Foldable (foldl',Foldable)
+import Data.Functor ((<$>))
 -- | A wrapper for any number, including Infinity and NegativeInfinity
 --   options.
 data Number a = Infinity | NegativeInfinity | Number a deriving (Show, Eq)

--- a/Data/Graph/Inductive/Query/SP/DAG.hs
+++ b/Data/Graph/Inductive/Query/SP/DAG.hs
@@ -1,101 +1,137 @@
+-- Module written by Hunter Herman
+-- Contact @ hherman1@macalester.edu
+-- | An implementation of O(N + E) algorithms for finding shortest
+--   and longest paths on directed acyclic graphs. Most functions
+--   require the input of a topological sort of the graph and 
+--   the length of the topological sort. A topological sort can
+--   be obtained with the 'topsort' function in Data.Graph.Inductive.Query.DFS
+--
+--   It is important to note that the library does not check if
+--   the input graph is a DAG. Unreliable results will be returned on 
+--   any other graph. 
+--   
+--   It may be of interest to some that it is not necessary to output a list
+--   of Nodes from these functions. The shortest/longest path functions are simple
+--   combinations of runPaths, tracePath, and Data.Vector.maxIndex. 
+--
+--   The algorithms are adaptations of the following:
+--   <https://en.wikipedia.org/wiki/Topological_sorting#Application_to_shortest_path_finding>
 module Data.Graph.Inductive.Query.SP.DAG (
       shortestPathBetweenNodes
-    , shortestPathFromSource
-    , shortestPath
     , longestPathBetweenNodes
     , longestPathFromSource
     , longestPath
     , tracePath
     , runPaths
+    , Number
 ) where
 
 import Prelude hiding (read)
 import Data.Graph.Inductive.Graph
-import Data.Vector (Vector,minIndex,maxIndex,freeze,(!))
+
+
+import Data.Graph.Inductive.PatriciaTree
+import Data.Graph.Inductive.Query.DFS
+
+
+import Data.Vector (Vector,maxIndex,freeze,(!))
 import Data.Vector.Mutable (IOVector,write,set,read,new)
 import Control.Monad (MonadPlus,mplus,mzero)
 import Data.Foldable (foldl')
 
+-- | A wrapper for any number, including Infinity and NegativeInfinity
+--   options.
+data Number a = Infinity | NegativeInfinity | Number a deriving (Show, Eq)
+
+instance Ord a => Ord (Number a) where
+    compare Infinity Infinity = EQ
+    compare Infinity _ = GT
+    compare _ Infinity = LT
+    compare NegativeInfinity NegativeInfinity = EQ
+    compare NegativeInfinity _ = LT
+    compare _ NegativeInfinity = GT
+    compare (Number x) (Number y) = compare x y
+
+instance Functor Number where
+    fmap f (Number x) = Number $ f x
+    fmap _ Infinity = Infinity
+    fmap _ NegativeInfinity = NegativeInfinity
+
+-- | Returns the shortest path between a start node and an end node.
 shortestPathBetweenNodes :: (Graph gr, Real b, Foldable f)
     => Node -- ^ Start
     -> Node -- ^ Destination
-    -> Int  -- ^ length of topsort
-    -> f Node -- ^ topsort
-    -> gr a b
+    -> Int  -- ^ Length of topsort
+    -> f Node -- ^ Topsort
+    -> gr a b -- ^ Graph
     -> IO Path
 shortestPathBetweenNodes s d l t g = do
-    (_,predecessor) <- runPaths (Just s) (Just 0) Nothing (<) l t g
+    (_,predecessor) <- runPaths (Just s) (Number 0) Infinity (>) l t g
     return $ tracePath d predecessor
 
-shortestPathFromSource :: (Graph gr, Real b, Foldable f)
-    => Node -- ^ Source
-    -> Int  -- ^ length of topsort
-    -> f Node -- ^ topsort
-    -> gr a b
-    -> IO Path
-shortestPathFromSource s l t g = do
-    (dist,predecessor) <- runPaths (Just s) (Just 0) Nothing (<) l t g
-    return $ tracePath (minIndex dist) predecessor
-
-shortestPath :: (Graph gr, Real b, Foldable f)
-    => Int  -- ^ length of topsort
-    -> f Node -- ^ topsort
-    -> gr a b
-    -> IO Path
-shortestPath l t g = do
-    (dist,predecessor) <- runPaths Nothing Nothing (Just 0) (<) l t g
-    return $ tracePath (minIndex dist) predecessor
-
+-- | Returns the longest path between a start node and an end node.
 longestPathBetweenNodes :: (Graph gr, Real b, Foldable f)
     => Node -- ^ Start
     -> Node -- ^ Destination
     -> Int  -- ^ length of topsort
     -> f Node -- ^ topsort
-    -> gr a b
+    -> gr a b -- ^ Graph
     -> IO Path
 longestPathBetweenNodes s d l t g = do
-    (_,predecessor) <- runPaths (Just s) (Just 0) Nothing (>) l t g
+    (_,predecessor) <- runPaths (Just s) (Number 0) NegativeInfinity (<) l t g
     return $ tracePath d predecessor
 
+-- | Returns the longest possible path from a source node.
 longestPathFromSource :: (Graph gr, Real b, Foldable f)
-    => Node -- ^ Source
-    -> Int  -- ^ length of topsort
-    -> f Node -- ^ topsort
-    -> gr a b
+    => Node -- ^ Source node
+    -> Int  -- ^ Length of topsort
+    -> f Node -- ^ Topsort
+    -> gr a b -- ^ Graph
     -> IO Path
 longestPathFromSource s l t g = do
-    (dist,predecessor) <- runPaths (Just s) (Just 0) Nothing (>) l t g
+    (dist,predecessor) <- runPaths (Just s) (Number 0) NegativeInfinity (<) l t g
     return $ tracePath (maxIndex dist) predecessor
 
+-- | Returns the longest possible path in the graph.
 longestPath :: (Graph gr, Real b, Foldable f)
     => Int  -- ^ length of topsort
     -> f Node -- ^ topsort
     -> gr a b
     -> IO Path
 longestPath l t g = do
-    (dist,predecessor) <- runPaths Nothing Nothing (Just 0) (>) l t g
+    (dist,predecessor) <- runPaths Nothing (Number 0) (Number 0) (<) l t g
     return $ tracePath (maxIndex dist) predecessor
 
+-- | Traces a path backwards through a vector of predecessors,
+--   where a vector of predecessors is a vector such that the value 
+--   in the vector at any position n where n is a node in the graph 
+--   is the predecessor to that node.
 tracePath :: MonadPlus m 
     => Node -- ^ End node of path
     -> Vector (Maybe Node) -- ^ Vector of predecessors
-    -> m Node
+    -> m Node -- ^ MonadPlus of Path
 tracePath n v = 
     case v ! n of
          Just node 
-              -> mplus (return node) $ tracePath node v
-         Nothing 
-              -> mzero
+              -> mplus (return n) $ tracePath node v
+         Nothing
+              -> mplus (return n) mzero
 
+-- | A reasonably generalized function used for generating 
+--   a vector of distances and predecessors obtained for a given
+--   comparison operation, an optional source node, and so on.
 runPaths :: (Graph gr, Real b, Foldable f)
     => Maybe Node -- Source node
-    -> Maybe b -- ^ Source node initialization value
-    -> Maybe b -- ^ Distances vector init values
-    -> (Maybe b -> Maybe b -> Bool) -- ^ Comparison to use on nodes
+    -> Number b -- ^ Source node initialization value
+    -> Number b -- ^ Distances vector init values
+    -> (Number b -> Number b -> Bool) -- ^ Weight multiplie
     -> Int -- ^ Length of the top sort
     -> f Node -- ^ Topological sorting of the graph in some foldable format
-    -> gr a b
-    -> IO (Vector (Maybe b), Vector (Maybe Node))
+    -> gr a b -- ^ A graph.
+-- | A vector of distances and predecessors. The distances represent maximum or
+--   minimum distance to a given node, and the predecessors represent the node that
+--   linked to that node on the maximum or minimum path.
+    -> IO (Vector (Number b), Vector (Maybe Node))
 runPaths s v ds c l t g = 
     freezeVecs =<< runPaths' s v ds c l t g
 
@@ -109,19 +145,19 @@ freezeVecs (v1,v2) = do
 
 runPaths' :: (Graph gr, Real b, Foldable f)
     => Maybe Node -- Source node
-    -> Maybe b -- ^ Source node initialization value
-    -> Maybe b -- ^ Distances vector init values
-    -> (Maybe b -> Maybe b -> Bool) -- ^ Comparison to use on nodes
+    -> Number b -- ^ Source node initialization value
+    -> Number b -- ^ Distances vector init values
+    -> (Number b -> Number b -> Bool) -- ^ Weight modifier
     -> Int -- ^ Length of the top sort
     -> f Node -- ^ Topological sorting of the graph in some foldable format
     -> gr a b
-    -> IO (IOVector (Maybe b), IOVector (Maybe Node))
-runPaths' s v distV comp n t g = do
+    -> IO (IOVector (Number b), IOVector (Maybe Node))
+runPaths' s v distV m n t g = do
     (distances,predecessors) <- genVectors n distV Nothing
     case s of 
          Just source -> write distances source v
          Nothing -> return ()
-    (newDistances,newPredecessors) <- pathsByComparison distances predecessors comp t g
+    (newDistances,newPredecessors) <- pathsByComparison distances predecessors m t g
     return (newDistances,newPredecessors)
 
 genVectors :: 
@@ -137,31 +173,31 @@ genVectors n val1 val2 = do
     return (distances,predecessors)
 
 pathsByComparison :: (Graph gr, Real b, Foldable f)
-    => IOVector (Maybe b) -- ^ Vector that will hold accumulated weights 
+    => IOVector (Number b) -- ^ Vector that will hold accumulated weights 
     -> IOVector (Maybe Node)
-    -> (Maybe b -> Maybe b -> Bool)
+    -> (Number b -> Number b -> Bool)
     -> f Node -- Topological sorting of the graph in some foldable format
     -> gr a b
-    -> IO (IOVector (Maybe b), IOVector (Maybe Node))
-pathsByComparison dist predecessor comp top graph =
-    foldl' (\_ node
-        -> updateSuccessors dist predecessor comp node graph)
+    -> IO (IOVector (Number b), IOVector (Maybe Node))
+pathsByComparison dist predecessor m top graph =
+    foldl' (\s node
+        -> s >> updateSuccessors dist predecessor m node graph)
         (return (dist, predecessor)) top 
 
 
 updateSuccessors :: (Graph gr, Real b)
-    => IOVector (Maybe b)
+    => IOVector (Number b)
     -> IOVector (Maybe Node)
-    -> (Maybe b -> Maybe b -> Bool)
+    -> (Number b -> Number b -> Bool)
     -> Node
     -> gr a b
-    -> IO (IOVector (Maybe b), IOVector (Maybe Node))
-updateSuccessors distances predecessors comparison t g = 
+    -> IO (IOVector (Number b), IOVector (Maybe Node))
+updateSuccessors distances predecessors comp t g = 
     let successors = lsuc g t in do
     sequence_ $ map (\(successor,weight) -> do
         ds <- read distances successor
         dt <- read distances t
-        if comparison ds ((+weight) <$> dt)
+        if comp ds ((+weight) <$> dt)
             then do
                 write distances successor $ (+weight) <$> dt
                 write predecessors successor $ Just t

--- a/Data/Graph/Inductive/Query/SP/DAG.hs
+++ b/Data/Graph/Inductive/Query/SP/DAG.hs
@@ -28,12 +28,6 @@ module Data.Graph.Inductive.Query.SP.DAG (
 
 import Prelude hiding (read)
 import Data.Graph.Inductive.Graph
-
-
-import Data.Graph.Inductive.PatriciaTree
-import Data.Graph.Inductive.Query.DFS
-
-
 import Data.Vector (Vector,maxIndex,freeze,(!))
 import Data.Vector.Mutable (IOVector,write,set,read,new)
 import Control.Monad (MonadPlus,mplus,mzero)

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -1,5 +1,5 @@
 name:          fgl
-version:       5.5.2.3
+version:       5.5.2.4
 license:       BSD3
 license-file:  LICENSE
 author:        Martin Erwig, Ivan Lazar Miljenovic

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -58,6 +58,7 @@ library {
         Data.Graph.Inductive.Query.MaxFlow2,
         Data.Graph.Inductive.Query.Monad,
         Data.Graph.Inductive.Query.SP,
+        Data.Graph.Inductive.Query.SP.DAG,
         Data.Graph.Inductive.Query.TransClos,
         Data.Graph.Inductive
 
@@ -67,6 +68,7 @@ library {
     build-depends:    base < 5
                     , transformers
                     , array
+                    , vector
 
     if flag(containers042)
         build-depends:    containers >= 0.4.2


### PR DESCRIPTION
Note: shortest/longest path algorithms output paths from the destination node to the source node, which could be considered reversed order. 

The algorithm is based on https://en.wikipedia.org/wiki/Topological_sorting#Application_to_shortest_path_finding

It is slightly generalized in runPaths' to allow easy implementation of the shortest/longest path functions. 

I don't believe theres any way to seriously simplify this module without losing the speed gains, although I'm open to suggestions!

Also, I don't believe its possible to implement this module in Hspec because:
- It requires IO to operate
- Theres no obvious type-level method to guarentee an acyclic graph...

Although I'm new to Hspec, so I could definitely be wrong. 
