### PR TITLE
Use bulk IntMap operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work
 cabal.config
 TAGS


### PR DESCRIPTION
Use `Data.IntMap.differenceWith` to implement `(&)` and `match`
for `Data.Graph.Inductive.PatriciaTree`. Instead of modifying
the graph manually, one key at a time, `differenceWith` will
efficiently partition the set of keys to be modified along the
structure of the graph. This should be considerably more efficient
when inserting or matching on well-connected nodes.

Fixes #39