### PR TITLE
Add cabal benchmark integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ script:
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
- - cabal check
  - cabal sdist   # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -79,7 +79,7 @@ library {
         build-depends:
             ghc-prim
 
-    ghc-options:      -Wall
+    ghc-options:      -Wall -O2
 
 }
 
@@ -104,6 +104,24 @@ test-suite fgl-tests {
                     , Data.Graph.Inductive.Proxy
                     , Data.Graph.Inductive.Query.Properties
 
-    ghc-options:      -Wall
+    ghc-options:      -Wall -O2
+
+}
+
+benchmark fgl-benchmark {
+    default-language: Haskell98
+
+    type: exitcode-stdio-1.0
+
+    hs-source-dirs: test
+
+    main-is: benchmark.hs
+
+    build-depends:   fgl
+                   , base
+                   , microbench
+                   , deepseq
+
+    ghc-options: -Wall -O2
 
 }


### PR DESCRIPTION
- Add the benchmarks to `fgl.cabal`.
- Disable AVL benchmarks that result in errors. Surely something
  needs to be fixed!
