### PR TITLE
allow pre' for bfs #52

### DIFF
--- a/Data/Graph/Inductive/Query/BFS.hs
+++ b/Data/Graph/Inductive/Query/BFS.hs
@@ -4,7 +4,7 @@
 module Data.Graph.Inductive.Query.BFS(
 
     -- * BFS Node List
-    bfs, bfsn, bfsWith, bfsnWith,
+    bfs, bfsn, bfsWith, bfsnWith, xbfsnWith,
 
     -- * Node List With Depth Info
     level, leveln,
@@ -27,22 +27,36 @@ import Data.Graph.Inductive.Internal.RootPath
 
 -- bfs (node list ordered by distance)
 --
-bfsnInternal :: (Graph gr) => (Context a b -> c) -> Queue Node -> gr a b -> [c]
-bfsnInternal f q g | queueEmpty q || isEmpty g = []
+bfsnInternal :: (Graph gr) => (Context a b -> [Node]) -> (Context a b -> c) -> Queue Node -> gr a b -> [c]
+bfsnInternal d f q g | queueEmpty q || isEmpty g = []
                    | otherwise                 =
        case match v g of
-        (Just c, g')  -> f c:bfsnInternal f (queuePutList (suc' c) q') g'
-        (Nothing, g') -> bfsnInternal f q' g'
+        (Just c, g')  -> f c:bfsnInternal d f (queuePutList (d c) q') g'
+        (Nothing, g') -> bfsnInternal d f q' g'
         where (v,q') = queueGet q
 
 bfsnWith :: (Graph gr) => (Context a b -> c) -> [Node] -> gr a b -> [c]
-bfsnWith f vs = bfsnInternal f (queuePutList vs mkQueue)
+bfsnWith = xbfsnWith suc'
+
+
+xbfsnWith :: (Graph gr) => 
+             (Context a b -> [Node]) -> -- ^ Mapping from a node to its neighbours to be visited
+                                        --   as well. 'suc'' for example makes 'xdfsWith'
+                                        --   traverse the graph following the edge directions,
+                                        --   while 'pre'' means reversed directions.
+             (Context a b -> c) ->      -- ^ Mapping from the 'Context' of a node to a result
+                                        --   value.
+             [Node] ->                  -- ^ Nodes to be visited.
+             gr a b -> 
+             [c]
+xbfsnWith d f vs = bfsnInternal d f (queuePutList vs mkQueue)
+
 
 bfsn :: (Graph gr) => [Node] -> gr a b -> [Node]
 bfsn = bfsnWith node'
 
 bfsWith :: (Graph gr) => (Context a b -> c) -> Node -> gr a b -> [c]
-bfsWith f v = bfsnInternal f (queuePut v mkQueue)
+bfsWith f v = bfsnInternal suc' f (queuePut v mkQueue)
 
 bfs :: (Graph gr) => Node -> gr a b -> [Node]
 bfs = bfsWith node'

--- a/Data/Graph/Inductive/Query/BFS.hs
+++ b/Data/Graph/Inductive/Query/BFS.hs
@@ -4,7 +4,7 @@
 module Data.Graph.Inductive.Query.BFS(
 
     -- * BFS Node List
-    bfs, bfsn, bfsWith, bfsnWith, xbfsnWith,
+    bfs, bfsn, bfsWith, xbfsWith, bfsnWith, xbfsnWith,
 
     -- * Node List With Depth Info
     level, leveln,
@@ -41,7 +41,7 @@ bfsnWith = xbfsnWith suc'
 
 xbfsnWith :: (Graph gr) => 
              (Context a b -> [Node]) -> -- ^ Mapping from a node to its neighbours to be visited
-                                        --   as well. 'suc'' for example makes 'xdfsWith'
+                                        --   as well. 'suc'' for example makes 'xbfsnWith'
                                         --   traverse the graph following the edge directions,
                                         --   while 'pre'' means reversed directions.
              (Context a b -> c) ->      -- ^ Mapping from the 'Context' of a node to a result
@@ -56,7 +56,10 @@ bfsn :: (Graph gr) => [Node] -> gr a b -> [Node]
 bfsn = bfsnWith node'
 
 bfsWith :: (Graph gr) => (Context a b -> c) -> Node -> gr a b -> [c]
-bfsWith f v = bfsnInternal suc' f (queuePut v mkQueue)
+bfsWith = xbfsWith suc'
+
+xbfsWith :: (Graph gr) => (Context a b -> [Node]) -> (Context a b -> c) -> Node -> gr a b -> [c]
+xbfsWith d f v = bfsnInternal d f (queuePut v mkQueue)
 
 bfs :: (Graph gr) => Node -> gr a b -> [Node]
 bfs = bfsWith node'


### PR DESCRIPTION
xdfsWith allows to specify suc' or pre' when performing the search. This allows to search in links as well as out links.

bfs is currently only possible with hard coded suc' : out links.

the suggested changes add an arg to bfsnInternal. This arg allows to pass suc' or pre' to bfs to search in-links as well as out-links.

current functions' signatures remain unchanged.

2 new functions are added:
xbfsWith
xbfsnWith
