### PR TITLE
Make DynGraph's `&` right associative to enable chaining

### DIFF
--- a/Data/Graph/Inductive/Graph.hs
+++ b/Data/Graph/Inductive/Graph.hs
@@ -178,6 +178,7 @@ class (Graph gr) => DynGraph gr where
   --
   --   Contexts should only refer to either a Node already in a graph
   --   or the node in the Context itself (for loops).
+  infixr 9 &
   (&) :: Context a b -> gr a b -> gr a b
 
 


### PR DESCRIPTION
Previously this wouldn't work

```
ctx1 & ctx2 & gr
```

Because `&` was left associative. This patch makes it working.
