### PR TITLE
Make shortest-path functions safer.

### DIFF
--- a/Data/Graph/Inductive/Internal/RootPath.hs
+++ b/Data/Graph/Inductive/Internal/RootPath.hs
@@ -19,7 +19,9 @@ first p xss  = case filter p xss of
                  []   -> []
                  x:_  -> x
 
--- | Find the first path in a tree that starts with the given node
+-- | Find the first path in a tree that starts with the given node.
+--
+--   Returns an empty list if there is no such path.
 findP :: Node -> LRTree a -> [LNode a]
 findP _ []                                = []
 findP v (LP []:ps)                        = findP v ps
@@ -32,8 +34,13 @@ getPath v = reverse . first (\(w:_)->w==v)
 getLPath :: Node -> LRTree a -> LPath a
 getLPath v = LP . reverse . findP v
 
-getDistance :: Node -> LRTree a -> a
-getDistance v = snd . head . findP v
+-- | Return the distance to the given node in the given tree.
+--
+--   Returns 'Nothing' if the given node is not reachable.
+getDistance :: Node -> LRTree a -> Maybe a
+getDistance v t = case findP v t of
+  []      -> Nothing
+  (_,d):_ -> Just d
 
 getLPathNodes :: Node -> LRTree a -> Path
 getLPathNodes v = (\(LP p)->map fst p) . getLPath v

--- a/Data/Graph/Inductive/Query/SP.hs
+++ b/Data/Graph/Inductive/Query/SP.hs
@@ -19,6 +19,9 @@ expand :: (Real b) => b -> LPath b -> Context a b -> [H.Heap b (LPath b)]
 expand d (LP p) (_,_,_,s) = map (\(l,v)->H.unit (l+d) (LP ((v,l+d):p))) s
 
 -- | Dijkstra's shortest path algorithm.
+--
+--   The edge labels of type @b@ are the edge weights; negative edge
+--   weights are not supported.
 dijkstra :: (Graph gr, Real b)
     => H.Heap b (LPath b) -- ^ Initial heap of known paths and their lengths.
     -> gr a b
@@ -35,24 +38,41 @@ dijkstra h g =
 --
 --   Corresponds to 'dijkstra' applied to a heap in which the only known node is
 --   the starting node, with a path of length 0 leading to it.
+--
+--   The edge labels of type @b@ are the edge weights; negative edge
+--   weights are not supported.
 spTree :: (Graph gr, Real b)
     => Node
     -> gr a b
     -> LRTree b
 spTree v = dijkstra (H.unit 0 (LP [(v,0)]))
 
--- | Length of the shortest path between two nodes.
+-- | Length of the shortest path between two nodes, if any.
+--
+--   Returns 'Nothing' if there is no path, and @'Just' <path length>@
+--   otherwise.
+--
+--   The edge labels of type @b@ are the edge weights; negative edge
+--   weights are not supported.
 spLength :: (Graph gr, Real b)
     => Node -- ^ Start
     -> Node -- ^ Destination
     -> gr a b
-    -> b
+    -> Maybe b
 spLength s t = getDistance t . spTree s
 
--- | Shortest path between two nodes.
+-- | Shortest path between two nodes, if any.
+--
+--   Returns 'Nothing' if the destination is not reachable from teh
+--   start node, and @'Just' <path>@ otherwise.
+--
+--   The edge labels of type @b@ are the edge weights; negative edge
+--   weights are not supported.
 sp :: (Graph gr, Real b)
     => Node -- ^ Start
     -> Node -- ^ Destination
     -> gr a b
-    -> Path
-sp s t = getLPathNodes t . spTree s
+    -> Maybe Path
+sp s t g = case getLPathNodes t (spTree s g) of
+  [] -> Nothing
+  p  -> Just p

--- a/test/TestSuite.hs
+++ b/test/TestSuite.hs
@@ -116,7 +116,10 @@ queryTests = describe "Queries" $ do
   test_maxFlow2
   test_maxFlow
   propP "msTree"       test_msTree
-  propP "sp"           test_sp
+  describe "SP" $ do
+    propP "sp"         test_sp
+    propP "sp_Just"    test_sp_Just
+    propP "sp_Nothing" test_sp_Nothing
   keepSmall $ do
     -- Just producing the sample graph to compare against is O(|V|^2)
     propP "trc"        test_trc


### PR DESCRIPTION
Namely:

- return `Nothing` instead of failing with the dreaded `*** Exception:
  Prelude.head: empty list` (for `spLength`) or returning
  non-sense (for `sp`) when the source is not connected to the
  destination.

- mention in the docs that negative edge weights will not produce the
  right answer.

- add tests that check that `Nothing` and `Just` are returned when
  they should be for shortest-path operations.

I just used your great library for the first time but wasted time with `Prelude.head: empty list` from `spLength`. This patch will avoid that problem for future users.