### PR TITLE
Use swap from Data.Tuple

### DIFF
--- a/Data/Graph/Inductive/PatriciaTree.hs
+++ b/Data/Graph/Inductive/PatriciaTree.hs
@@ -32,6 +32,7 @@ import           Data.IntMap         (IntMap)
 import qualified Data.IntMap         as IM
 import           Data.List           (foldl', sort)
 import           Data.Maybe          (fromMaybe)
+import           Data.Tuple          (swap)
 
 #if MIN_VERSION_containers (0,4,2)
 import Control.DeepSeq (NFData(..))
@@ -258,9 +259,6 @@ toContext v (ps, a, ss) = (toAdj ps, v, a, toAdj ss)
 
 fromContext :: Context a b -> Context' a b
 fromContext (ps, _, a, ss) = (fromAdj ps, a, fromAdj ss)
-
-swap :: (a, b) -> (b, a)
-swap (a, b) = (b, a)
 
 -- A version of @++@ where order isn't important, so @xs ++ [x]@
 -- becomes @x:xs@.  Used when we have to have a function of type @[a]

--- a/Data/Graph/Inductive/Query/DFS.hs
+++ b/Data/Graph/Inductive/Query/DFS.hs
@@ -50,7 +50,7 @@ import Data.Graph.Inductive.Graph
 import Data.Tree
 import qualified Data.Map as Map
 import Control.Monad (liftM2)
-
+import Data.Tuple (swap)
 
 
 -- | Many functions take a list of nodes to visit as an explicit argument.
@@ -243,8 +243,6 @@ condensation gr = mkGraph vs es
     sccs = scc gr
     vs = zip [1..] sccs
     vMap = Map.fromList $ map swap vs
-
-    swap = uncurry $ flip (,)
 
     getN = (vMap Map.!)
     es = [ (getN c1, getN c2, ()) | c1 <- sccs, c2 <- sccs

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -65,7 +65,7 @@ library {
     other-modules:
         Paths_fgl
 
-    build-depends:    base < 5
+    build-depends:    base >= 4.3 && < 5
                     , transformers
                     , array
 


### PR DESCRIPTION
While reading the code, I saw two different definitions of `swap` defined in `Data.Tuple` since `base-4.3.0.0` .
Here is a fix.