### PR TITLE
Fix implementation of rc in TransClos.

### DIFF
--- a/Data/Graph/Inductive/Query/TransClos.hs
+++ b/Data/Graph/Inductive/Query/TransClos.hs
@@ -34,7 +34,8 @@ Given a graph G=(V,E), its transitive closure is the graph:
 G* = (V,Er union E) where Er = {(i,i): i in V}
 -}
 rc :: (DynGraph gr) => gr a b -> gr a ()
-rc g = newEdges `insEdges` insNodes ln empty
+rc g = (newEdges ++ oldEdges) `insEdges` insNodes ln empty
   where
     ln       = labNodes g
     newEdges = [ (u, u, ()) | (u, _) <- ln ]
+    oldEdges = [ (u, v, ()) | (u, v, _) <- labEdges g ]


### PR DESCRIPTION
As observed in issue #86,
the implementation of the function rc
in the module Data.Graph.Inductive.Query.TransClos
computes the graph with only the self-loops,
rather than the reflexive closure of a graph.

This change conserves the existing edges,
although it drops their labels in the process
to satisfy the desired type of the function.