### PR TITLE
Updating upper bound versions of dependencies.

### DIFF
--- a/fgl-arbitrary/fgl-arbitrary.cabal
+++ b/fgl-arbitrary/fgl-arbitrary.cabal
@@ -33,7 +33,7 @@ library
   -- other-extensions:
   build-depends:       base < 5
                      , fgl >= 5.5.2.0 && < 6
-                     , QuickCheck >= 2.3 && < 2.13
+                     , QuickCheck >= 2.3 && <= 2.13.2
   -- hs-source-dirs:
   default-language:    Haskell2010
 
@@ -47,8 +47,8 @@ test-suite fgl-arbitrary-tests
     build-depends:    fgl-arbitrary
                     , fgl
                     , base
-                    , QuickCheck >= 2.3 && < 2.13
-                    , hspec >= 2.1 && < 2.7
+                    , QuickCheck >= 2.3 && <= 2.13.2
+                    , hspec >= 2.1 && <= 2.7.1
                     , containers
 
     hs-source-dirs:   test


### PR DESCRIPTION
fgl-arbitrary is a dependency of graphviz, which would be great to have included in recent and current LTS versions in stackage. In order to achieve this, fgl-arbitrary would be one of the component to be updated in hackage.

A new version would be nice to have on Hackage, but updating the version bounds in the currently available version is also a working solution which I have just tested.