### PR TITLE
Fix dom function calculation of dominators.

### DIFF
--- a/Data/Graph/Inductive/Query/Dominators.hs
+++ b/Data/Graph/Inductive/Query/Dominators.hs
@@ -51,6 +51,7 @@ type FromNode = IntMap Node'
 
 idomWork :: (Graph gr) => gr a b -> Node -> (IDom, ToNode, FromNode)
 idomWork g root = let
+    nds = reachable root g
     -- use depth first tree from root do build the first approximation
     trees@(~[tree]) = dff [root] g
     -- relabel the tree so that paths from the root have increasing nodes
@@ -58,7 +59,7 @@ idomWork g root = let
     -- the approximation iDom0 just maps each node to its parent
     iD0 = array (1, s-1) (tail $ treeEdges (-1) ntree)
     -- fromNode translates graph nodes to relabeled (internal) nodes
-    fromNode = I.unionWith const (I.fromList (zip (T.flatten tree) (T.flatten ntree))) (I.fromList (zip (nodes g) (repeat (-1))))
+    fromNode = I.unionWith const (I.fromList (zip (T.flatten tree) (T.flatten ntree))) (I.fromList (zip nds (repeat (-1))))
     -- toNode translates internal nodes to graph nodes
     toNode = array (0, s-1) (zip (T.flatten ntree) (T.flatten tree))
     preds = array (1, s-1) [(i, filter (/= -1) (map (fromNode I.!)

--- a/test/Data/Graph/Inductive/Query/Properties.hs
+++ b/test/Data/Graph/Inductive/Query/Properties.hs
@@ -133,14 +133,22 @@ test_condensation _ g = sort sccs == sort (map snd $ labNodes cdg)
 -- Dominators
 
 test_dom :: Spec
-test_dom = it "dom" $
-  sortIt (dom domGraph 1) `shouldMatchList` [ (1, [1])
-                                            , (2, [1,2])
-                                            , (3, [1,2,3])
-                                            , (4, [1,2,4])
-                                            , (5, [1,2,5])
-                                            , (6, [1,2,6])
-                                            ]
+test_dom = describe "dom" $ do
+  it "regular dom" $
+    sortIt (dom domGraph 1) `shouldMatchList` [ (1, [1])
+                                              , (2, [1,2])
+                                              , (3, [1,2,3])
+                                              , (4, [1,2,4])
+                                              , (5, [1,2,5])
+                                              , (6, [1,2,6])
+                                              ]
+  it "multiple components dom" $
+    sortIt (dom domGraph1 1) `shouldMatchList` [ (1, [1])
+                                               , (2, [1, 2])
+                                               ]
+  it "directed reachable components dom" $
+    sortIt (dom domGraph2 1) `shouldMatchList` [ (1, [1]) ]
+
   where
     sortIt = map (second sort)
 
@@ -159,6 +167,20 @@ domGraph = mkUGraph [1..6]
                     , (4,5)
                     , (5,2)
                     ]
+
+-- This graph has two components (independent subgraphs)
+domGraph1 :: Gr () ()
+domGraph1 = mkUGraph [1..3]
+                     [ (1,2)
+                     ]
+
+-- This graph has no reachables from 1 (but 1 is reachable)
+domGraph2 :: Gr () ()
+domGraph2 = mkUGraph [1..3]
+                     [ (2,1)
+                     , (2,2)
+                     ]
+
 
 -- -----------------------------------------------------------------------------
 -- GVD


### PR DESCRIPTION
Currently the dom function returns *all* nodes whether they are reachable or not.  This change restricts the dominator search to only those nodes reachable from the provided root.