### PR TITLE
Fix most/all warnings

### DIFF
--- a/Data/Graph/Inductive/Graph.hs
+++ b/Data/Graph/Inductive/Graph.hs
@@ -156,9 +156,10 @@ class Graph gr where
   matchAny  :: gr a b -> GDecomp gr a b
   matchAny g = case labNodes g of
                  []      -> error "Match Exception, Empty Graph"
-                 (v,_):_ -> (c,g')
-                   where
-                     (Just c,g') = match v g
+                 (v,_):_ ->
+                   case match v g of
+                     (Just c,g') -> (c,g')
+                     _ -> error "Match Exception, cannot extract node"
 
   -- | The number of 'Node's in a 'Graph'.
   noNodes   :: gr a b -> Int

--- a/Data/Graph/Inductive/Internal/RootPath.hs
+++ b/Data/Graph/Inductive/Internal/RootPath.hs
@@ -29,7 +29,7 @@ findP v (LP (p@((w,_):_)):ps) | v==w      = p
                               | otherwise = findP v ps
 
 getPath :: Node -> RTree -> Path
-getPath v = reverse . first (\(w:_)->w==v)
+getPath v = reverse . first ((==v) . head)
 
 getLPath :: Node -> LRTree a -> LPath a
 getLPath v = LP . reverse . findP v

--- a/Data/Graph/Inductive/Monad.hs
+++ b/Data/Graph/Inductive/Monad.hs
@@ -56,8 +56,10 @@ class (Monad m) => GraphM m gr where
   matchAnyM g = do vs <- labNodesM g
                    case vs of
                      []      -> error "Match Exception, Empty Graph"
-                     (v,_):_ -> do ~(Just c,g') <- matchM v g
-                                   return (c,g')
+                     (v,_):_ -> do r <- matchM v g
+                                   case r of
+                                     (Just c,g') -> return (c,g')
+                                     _ -> error "Match Exception, cannot extract node"
 
   noNodesM   :: m (gr a b) -> m Int
   noNodesM = labNodesM >>. length

--- a/Data/Graph/Inductive/NodeMap.hs
+++ b/Data/Graph/Inductive/NodeMap.hs
@@ -114,8 +114,8 @@ insMapNode_ m a g =
 
 insMapEdge :: (Ord a, DynGraph g) => NodeMap a -> (a, a, b) -> g a b -> g a b
 insMapEdge m e g =
-    let (Just e') = mkEdge m e
-    in insEdge e' g
+  case mkEdge m e of Just e' -> insEdge e' g
+                     Nothing -> error "insMapEdge: invalid edge"
 
 delMapNode :: (Ord a, DynGraph g) => NodeMap a -> a -> g a b -> g a b
 delMapNode m a g =
@@ -124,8 +124,8 @@ delMapNode m a g =
 
 delMapEdge :: (Ord a, DynGraph g) => NodeMap a -> (a, a) -> g a b -> g a b
 delMapEdge m (n1, n2) g =
-    let Just (n1', n2', _) = mkEdge m (n1, n2, ())
-    in delEdge (n1', n2') g
+    case mkEdge m (n1, n2, ()) of Just (n1', n2', _) -> delEdge (n1', n2') g
+                                  Nothing -> error "delMapEdge: invalid edge"
 
 insMapNodes :: (Ord a, DynGraph g) => NodeMap a -> [a] -> g a b -> (g a b, NodeMap a, [LNode a])
 insMapNodes m as g =
@@ -139,8 +139,8 @@ insMapNodes_ m as g =
 
 insMapEdges :: (Ord a, DynGraph g) => NodeMap a -> [(a, a, b)] -> g a b -> g a b
 insMapEdges m es g =
-    let Just es' = mkEdges m es
-    in insEdges es' g
+    case mkEdges m es of Just es' -> insEdges es' g
+                         Nothing -> error "insMapEdges: invalid edge"
 
 delMapNodes :: (Ord a, DynGraph g) => NodeMap a -> [a] -> g a b -> g a b
 delMapNodes m as g =
@@ -149,15 +149,18 @@ delMapNodes m as g =
 
 delMapEdges :: (Ord a, DynGraph g) => NodeMap a -> [(a, a)] -> g a b -> g a b
 delMapEdges m ns g =
-    let Just ns' =  mkEdges m $ P.map (\(a, b) -> (a, b, ())) ns
-        ns'' = P.map (\(a, b, _) -> (a, b)) ns'
-    in delEdges ns'' g
+    case mkEdges m $ P.map (\(a, b) -> (a, b, ())) ns of
+      Nothing -> error "delMapEdges: invalid edges"
+      Just ns' ->
+        let ns'' = P.map (\(a, b, _) -> (a, b)) ns'
+        in delEdges ns'' g
 
 mkMapGraph :: (Ord a, DynGraph g) => [a] -> [(a, a, b)] -> (g a b, NodeMap a)
 mkMapGraph ns es =
     let (ns', m') = mkNodes new ns
-        Just es' = mkEdges m' es
-    in (mkGraph ns' es', m')
+    in case mkEdges m' es of
+         Just es' -> (mkGraph ns' es', m')
+         Nothing -> error "mkMapGraph: invalid edges"
 
 -- | Graph construction monad; handles passing both the 'NodeMap' and the
 -- 'Graph'.

--- a/Data/Graph/Inductive/Query/BCC.hs
+++ b/Data/Graph/Inductive/Query/BCC.hs
@@ -43,10 +43,11 @@ findGraph v (g:gs) = case match v g of
 splitGraphs :: (DynGraph gr) => [gr a b] -> [Node] -> [gr a b]
 splitGraphs gs []     = gs
 splitGraphs [] _      = error "splitGraphs: empty graph list"
-splitGraphs gs (v:vs) = splitGraphs (gs''++gs''') vs
-                        where gs'' = embedContexts c gs'
-                              gs' = gComponents g'
-                              ((Just c,g'), gs''') = findGraph v gs
+splitGraphs gs (v:vs) = case findGraph v gs of
+                          ((Nothing, _), _) -> error "splitGraphs: invalid node"
+                          ((Just c,g'), gs''') -> splitGraphs (gs''++gs''') vs
+                            where gs'' = embedContexts c gs'
+                                  gs' = gComponents g'
 
 {-|
 Finds the bi-connected components of an undirected connected graph.

--- a/Data/Graph/Inductive/Query/BFS.hs
+++ b/Data/Graph/Inductive/Query/BFS.hs
@@ -107,10 +107,12 @@ bft v = bf (queuePut [v] mkQueue)
 bf :: (Graph gr) => Queue Path -> gr a b -> RTree
 bf q g | queueEmpty q || isEmpty g = []
        | otherwise                 =
-       case match v g of
-         (Just c, g')  -> p:bf (queuePutList (map (:p) (suc' c)) q') g'
-         (Nothing, g') -> bf q' g'
-         where (p@(v:_),q') = queueGet q
+       case queueGet q of
+         ([], _) -> []
+         (p@(v:_),q') ->
+           case match v g of
+             (Just c, g')  -> p:bf (queuePutList (map (:p) (suc' c)) q') g'
+             (Nothing, g') -> bf q' g'
 
 esp :: (Graph gr) => Node -> Node -> gr a b -> Path
 esp s t = getPath t . bft s
@@ -128,11 +130,13 @@ lbft v g = case out g v of
 lbf :: (Graph gr) => Queue (LPath b) -> gr a b -> LRTree b
 lbf q g | queueEmpty q || isEmpty g = []
         | otherwise                 =
-       case match v g of
-         (Just c, g') ->
-             LP p:lbf (queuePutList (map (\v' -> LP (v':p)) (lsuc' c)) q') g'
-         (Nothing, g') -> lbf q' g'
-         where (LP (p@((v,_):_)),q') = queueGet q
+       case queueGet q of
+         (LP [], _) -> []
+         (LP (p@((v,_):_)),q') ->
+           case match v g of
+             (Just c, g') ->
+                 LP p:lbf (queuePutList (map (\v' -> LP (v':p)) (lsuc' c)) q') g'
+             (Nothing, g') -> lbf q' g'
 
 lesp :: (Graph gr) => Node -> Node -> gr a b -> LPath b
 lesp s t = getLPath t . lbft s

--- a/Data/Graph/Inductive/Query/Indep.hs
+++ b/Data/Graph/Inductive/Query/Indep.hs
@@ -22,12 +22,14 @@ indep = fst . indepSize
 indepSize :: (DynGraph gr) => gr a b -> ([Node], Int)
 indepSize g
   | isEmpty g = ([], 0)
-  | l1 > l2   = il1
-  | otherwise = il2
+  | otherwise =
+      case match v g of
+        (Nothing,_) -> error "indepSize: unexpected invalid node"
+        (Just c,g') ->
+          let il1@(_,l1)  = indepSize g'
+              il2@(_,l2)  = ((v:) *** (+1)) $ indepSize (delNodes (neighbors' c) g')
+          in if l1 > l2 then il1 else il2
   where
     vs          = nodes g
     v           = snd . maximumBy (compare `on` fst)
                   . map ((,) =<< deg g) $ vs
-    (Just c,g') = match v g
-    il1@(_,l1)  = indepSize g'
-    il2@(_,l2)  = ((v:) *** (+1)) $ indepSize (delNodes (neighbors' c) g')

--- a/Data/Graph/Inductive/Query/MST.hs
+++ b/Data/Graph/Inductive/Query/MST.hs
@@ -20,10 +20,12 @@ newEdges (LP p) (_,_,_,s) = map (\(l,v)->H.unit l (LP ((v,l):p))) s
 prim :: (Graph gr,Real b) => H.Heap b (LPath b) -> gr a b -> LRTree b
 prim h g | H.isEmpty h || isEmpty g = []
 prim h g =
-    case match v g of
-         (Just c,g')  -> p:prim (H.mergeAll (h':newEdges p c)) g'
-         (Nothing,g') -> prim h' g'
-    where (_,p@(LP ((v,_):_)),h') = H.splitMin h
+  case H.splitMin h of
+    (_,p@(LP ((v,_):_)),h') ->
+      case match v g of
+           (Just c,g')  -> p:prim (H.mergeAll (h':newEdges p c)) g'
+           (Nothing,g') -> prim h' g'
+    _ -> []
 
 msTreeAt :: (Graph gr,Real b) => Node -> gr a b -> LRTree b
 msTreeAt v = prim (H.unit 0 (LP [(v,0)]))

--- a/Data/Graph/Inductive/Query/MaxFlow.hs
+++ b/Data/Graph/Inductive/Query/MaxFlow.hs
@@ -64,10 +64,11 @@ augmentGraph g = emap (\i->(i,0,i)) (insEdges (getRevEdges (edges g)) g)
 --   residual capacity of that edge's label. Then return the updated
 --   list.
 updAdjList::(Num b) => Adj (b,b,b) -> Node -> b -> Bool -> Adj (b,b,b)
-updAdjList s v cf fwd = rs ++ ((x,y+cf',z-cf'),w) : rs'
+updAdjList s v cf fwd =
+  case break ((v==) . snd) s of
+    (rs, ((x,y,z),w):rs') -> rs ++ ((x,y+cf',z-cf'),w) : rs'
+    _ -> error "updAdjList: invalid node"
   where
-    (rs, ((x,y,z),w):rs') = break ((v==) . snd) s
-
     cf' = if fwd
              then cf
              else negate cf

--- a/Data/Graph/Inductive/Query/Monad.hs
+++ b/Data/Graph/Inductive/Query/Monad.hs
@@ -218,14 +218,15 @@ dffM :: (GraphM m gr) => [Node] -> GT m (gr a b) [Tree Node]
 dffM vs = MGT (\mg->
           do g<-mg
              b<-isEmptyM mg
-             if b||null vs then return ([],g) else
-                let (v:vs') = vs in
-                do (mc,g1) <- matchM v mg
+             case (b, vs) of
+               (False, v:vs') -> do
+                   (mc,g1) <- matchM v mg
                    case mc of
                      Nothing -> apply (dffM vs') (return g1)
                      Just c  -> do (ts, g2) <- apply (dffM (suc' c)) (return g1)
                                    (ts',g3) <- apply (dffM vs') (return g2)
                                    return (Node (node' c) ts:ts',g3)
+               _ -> return ([],g)
           )
 
 graphDff :: (GraphM m gr) => [Node] -> m (gr a b) -> m [Tree Node]

--- a/Data/Graph/Inductive/Query/SP.hs
+++ b/Data/Graph/Inductive/Query/SP.hs
@@ -28,10 +28,12 @@ dijkstra :: (Graph gr, Real b)
     -> LRTree b
 dijkstra h g | H.isEmpty h || isEmpty g = []
 dijkstra h g =
-    case match v g of
-         (Just c,g')  -> p:dijkstra (H.mergeAll (h':expand d p c)) g'
-         (Nothing,g') -> dijkstra h' g'
-    where (_,p@(LP ((v,d):_)),h') = H.splitMin h
+  case H.splitMin h of
+    (_,p@(LP ((v,d):_)),h') ->
+      case match v g of
+           (Just c,g')  -> p:dijkstra (H.mergeAll (h':expand d p c)) g'
+           (Nothing,g') -> dijkstra h' g'
+    _ -> []
 
 -- | Tree of shortest paths from a certain node to the rest of the
 --   (reachable) nodes.

--- a/fgl-arbitrary/Data/Graph/Inductive/Arbitrary.hs
+++ b/fgl-arbitrary/Data/Graph/Inductive/Arbitrary.hs
@@ -321,23 +321,24 @@ instance (ArbGraph ag, Arbitrary a, Arbitrary b) => Arbitrary (Connected ag a b)
 
 toConnGraph :: forall ag a b. (ArbGraph ag, Arbitrary a, Arbitrary b)
                => ag a b -> Gen (Connected ag a b)
-toConnGraph ag = do a <- arbitrary
-                    ces <- concat <$> mapM mkE ws
-                    return $ CG { connNode     = v
-                                , connArbGraph = fromBaseGraph
-                                                 . insEdges ces
-                                                 . insNode (v,a)
-                                                 $ g
-                                }
+toConnGraph ag = case newNodes 1 g of
+                   [] -> error "toConnGraph: cannot make node"
+                   v:_ -> do
+                     a <- arbitrary
+                     ces <- concat <$> mapM (mkE v) ws
+                     return $ CG { connNode     = v
+                                 , connArbGraph = fromBaseGraph
+                                                  . insEdges ces
+                                                  . insNode (v,a)
+                                                  $ g
+                                 }
   where
     g = toBaseGraph ag
 
-    [v] = newNodes 1 g
-
     ws = nodes g
 
-    mkE w = do b <- arbitrary
-               return (edgeF p [(v,w,b)])
+    mkE v w = do b <- arbitrary
+                 return (edgeF p [(v,w,b)])
 
     p :: GrProxy ag
     p = GrProxy

--- a/fgl-arbitrary/fgl-arbitrary.cabal
+++ b/fgl-arbitrary/fgl-arbitrary.cabal
@@ -38,6 +38,9 @@ library
   default-language:    Haskell2010
 
   ghc-options:         -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:       -Wall -Wno-star-is-type
+
 
 test-suite fgl-arbitrary-tests
     default-language: Haskell2010

--- a/fgl.cabal
+++ b/fgl.cabal
@@ -107,6 +107,8 @@ test-suite fgl-tests {
                     , Data.Graph.Inductive.Query.Properties
 
     ghc-options:      -Wall
+    if impl(ghc >= 8.0)
+      ghc-options:    -Wall -Wno-star-is-type
 
 }
 

--- a/test/Data/Graph/Inductive/Query/Properties.hs
+++ b/test/Data/Graph/Inductive/Query/Properties.hs
@@ -361,26 +361,29 @@ test_sp _ cg = all test_p (map unLPath (msTree g))
 test_sp_Just :: (ArbGraph gr, Graph gr, Real b) =>
   Proxy (gr a b) -> gr a b -> Property
 test_sp_Just _ g =
-  (noNodes g >= 2 && v `elem` bfs u g) ==>
-  isJust (spLength u v g) &&
-  isJust maybePath &&
-  not (null path) &&
-  head path == u &&
-  last path == v
-  where
-    [u,v] = take 2 (nodes g)
-    maybePath@(Just path) = sp u v g
+  case nodes g of
+    u:v:_ ->
+      v `elem` bfs u g ==>
+      isJust (spLength u v g) &&
+      case sp u v g of
+        Nothing -> False
+        Just path ->
+          not (null path) &&
+          head path == u &&
+          last path == v
+    _ -> property True
 
 -- | Test that 'spLength' and 'sp' return 'Nothing' when destination
 --   is not reachable from source.
 test_sp_Nothing :: (ArbGraph gr, Graph gr, Real b) =>
   Proxy (gr a b) -> gr a b -> Property
 test_sp_Nothing _ g =
-  (noNodes g >= 2 && not (v `elem` bfs u g)) ==>
-  isNothing (spLength u v g) &&
-  isNothing (sp u v g)
-  where
-    [u,v] = take 2 (nodes g)
+  case nodes g of
+    u:v:_ ->
+      not (v `elem` bfs u g) ==>
+        isNothing (spLength u v g) &&
+        isNothing (sp u v g)
+    _ -> property True
 
 -- -----------------------------------------------------------------------------
 -- TransClos


### PR DESCRIPTION
It was getting a bit difficult to see which warnings might be indicative of problems, so I fixed the various unmatched-case warnings.

I tried to be conservative in order to minimise the risk of breakage, so there might be a few cases where edge cases are checked using both Boolean control flow and pattern matching.