### PR TITLE
Remove HLint ANN pragmas

### DIFF
--- a/Data/Graph/Inductive/Monad.hs
+++ b/Data/Graph/Inductive/Monad.hs
@@ -20,8 +20,6 @@ module Data.Graph.Inductive.Monad(
 
 import Data.Graph.Inductive.Graph
 
-{-# ANN module "HLint: ignore Redundant lambda" #-}
-
 ----------------------------------------------------------------------
 -- MONADIC GRAPH CLASS
 ----------------------------------------------------------------------

--- a/Data/Graph/Inductive/Query/Dominators.hs
+++ b/Data/Graph/Inductive/Query/Dominators.hs
@@ -21,7 +21,6 @@ import           Data.Maybe (mapMaybe)
 import           Data.Tree                      (Tree (..))
 import qualified Data.Tree                      as T
 
-{-# ANN iDom "HLint: ignore Use ***" #-}
 -- | return immediate dominators for each reachable node of a graph, given a root
 iDom :: (Graph gr) => gr a b -> Node -> [(Node,Node)]
 iDom g root = let (result, toNode, _) = idomWork g root


### PR DESCRIPTION
I considered instead replacing these with the modern style recommended by HLint, which is just a plain comment. But actually, there are various other HLint hints triggered in this project which aren't ignored at all. And one of the hints being ignored doesn't trigger anyway.

As for why this matters, `ANN` pragmas require Template Haskell. And there are many reasons one may wish to avoid TH when it's possible to do so, e.g. for simpler cross compilation.